### PR TITLE
Update nightly-tests to use the latest prod version of the sdk (release-0.22)

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -66,7 +66,7 @@ jobs:
       environment: prod
       runs_on: ubuntu-latest
       branch: main
-      package_spec: dbnl@git+ssh://git@github.com/dbnlAI/dbnl-sdk.git@release-0.21
+      package_spec: dbnl@git+ssh://git@github.com/dbnlAI/dbnl-sdk.git@release-0.22
     secrets: inherit
     concurrency:
       group: prod-${{ matrix.python_version }}-${{ matrix.notebook_dir }}/${{ matrix.notebook_file }}


### PR DESCRIPTION
### 📌 Summary
This updates the nightly tests to use the latest version of the prod sdk: 0.21

### ❓ Ticket / Justification
This is a regular part of the release process

### 🧪 Test plan
This doesn't need to be tested.
